### PR TITLE
feat: add HR AI hub webapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# codex
+# Hub de Especialistas de RH
+
+Este projeto demonstra um pequeno WebApp que serve como hub para vários agentes de IA focados em Gestão de Pessoas. A tela inicial apresenta três especialistas e, ao selecionar um deles, abre-se um chat com um _prompt_ de sistema específico.
+
+## Executando
+
+1. Defina a variável de ambiente `OPENAI_API_KEY` com sua chave da OpenAI (opcional; sem a chave o servidor retornará uma mensagem de configuração ausente).
+2. Inicie o servidor:
+
+```bash
+npm start
+```
+
+3. Acesse `http://localhost:3000` no navegador para utilizar o hub.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "codex",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <title>Hub de Especialistas de RH</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    #agents button { margin-right: 10px; }
+    #chat { margin-top: 20px; }
+    #messages { border: 1px solid #ccc; padding: 10px; height: 200px; overflow-y: auto; margin-bottom: 10px; }
+  </style>
+</head>
+<body>
+  <h1>Especialistas de RH</h1>
+  <div id="agents">
+    <button data-agent="recrutamento">Especialista em Recrutamento</button>
+    <button data-agent="engajamento">Especialista em Engajamento</button>
+    <button data-agent="treinamento">Especialista em Treinamento</button>
+  </div>
+  <div id="chat" style="display:none;">
+    <h2 id="agent-title"></h2>
+    <div id="messages"></div>
+    <input id="input" placeholder="Digite sua pergunta" />
+    <button id="send">Enviar</button>
+  </div>
+  <script>
+    const agentNames = {
+      recrutamento: 'Especialista em Recrutamento',
+      engajamento: 'Especialista em Engajamento',
+      treinamento: 'Especialista em Treinamento'
+    };
+    let currentAgent = null;
+    document.querySelectorAll('#agents button').forEach(btn => {
+      btn.addEventListener('click', () => {
+        currentAgent = btn.dataset.agent;
+        document.getElementById('agent-title').textContent = agentNames[currentAgent];
+        document.getElementById('chat').style.display = 'block';
+        document.getElementById('messages').innerHTML = '';
+      });
+    });
+    async function sendMessage() {
+      const input = document.getElementById('input');
+      const text = input.value.trim();
+      if (!text) return;
+      appendMessage('Você', text);
+      input.value = '';
+      const res = await fetch('/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ agent: currentAgent, message: text })
+      });
+      const data = await res.json();
+      appendMessage(agentNames[currentAgent], data.reply);
+    }
+    function appendMessage(sender, text) {
+      const div = document.createElement('div');
+      div.textContent = sender + ': ' + text;
+      document.getElementById('messages').appendChild(div);
+    }
+    document.getElementById('send').addEventListener('click', sendMessage);
+    document.getElementById('input').addEventListener('keypress', e => {
+      if (e.key === 'Enter') sendMessage();
+    });
+  </script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,70 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const agents = {
+  recrutamento: 'Você é um especialista em recrutamento e seleção, ajudando com estratégias para encontrar e contratar os melhores talentos.',
+  engajamento: 'Você é um especialista em engajamento de colaboradores, fornecendo dicas para motivação e satisfação no trabalho.',
+  treinamento: 'Você é um especialista em treinamento e desenvolvimento, orientando planos de capacitação e crescimento profissional.'
+};
+
+const server = http.createServer(async (req, res) => {
+  if (req.method === 'GET') {
+    const filePath = path.join(__dirname, 'public', req.url === '/' ? 'index.html' : req.url);
+    fs.readFile(filePath, (err, data) => {
+      if (err) {
+        res.writeHead(404);
+        res.end('Not found');
+      } else {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(data);
+      }
+    });
+  } else if (req.method === 'POST' && req.url === '/chat') {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', async () => {
+      try {
+        const { agent, message } = JSON.parse(body);
+        const system = agents[agent] || 'Você é um assistente de RH.';
+        const apiKey = process.env.OPENAI_API_KEY;
+        let reply = 'Configuração de API ausente.';
+        if (apiKey) {
+          try {
+            const resp = await fetch('https://api.openai.com/v1/chat/completions', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${apiKey}`
+              },
+              body: JSON.stringify({
+                model: 'gpt-4o-mini',
+                messages: [
+                  { role: 'system', content: system },
+                  { role: 'user', content: message }
+                ]
+              })
+            });
+            const data = await resp.json();
+            reply = data?.choices?.[0]?.message?.content || 'Sem resposta.';
+          } catch (e) {
+            reply = 'Erro ao consultar o modelo.';
+          }
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ reply }));
+      } catch (e) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Erro no servidor' }));
+      }
+    });
+  } else {
+    res.writeHead(404);
+    res.end('Not found');
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Servidor iniciado na porta ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add minimal Node.js server with multiple HR-focused AI specialists and OpenAI integration
- create front-end hub listing specialists and chat interface
- document usage and setup in README

## Testing
- `npm test`
- `node server.js` (server startup) and `curl http://localhost:3000`


------
https://chatgpt.com/codex/tasks/task_e_68a60ad206788332bec6545906a8fe38