### PR TITLE
feat: convert frontend to React with Material UI design

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# codex
+# Hub de Especialistas de RH
+
+Este projeto demonstra um pequeno WebApp que serve como hub para vários agentes de IA focados em Gestão de Pessoas. A interface utiliza **React** com o framework **Material UI** para oferecer um layout responsivo em azul e branco, com ícones que representam cada especialista e um chat estilizado para a conversa.
+
+## Executando
+
+1. Defina a variável de ambiente `OPENAI_API_KEY` com sua chave da OpenAI (opcional; sem a chave o servidor retornará uma mensagem de configuração ausente).
+2. Inicie o servidor:
+
+```bash
+npm start
+```
+
+3. Acesse `http://localhost:3000` no navegador para utilizar o hub.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "codex",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Hub de Especialistas de RH</title>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <script crossorigin src="https://unpkg.com/@mui/material@5.15.8/umd/material-ui.development.js"></script>
+  <script crossorigin src="https://unpkg.com/@mui/icons-material@5.15.8/umd/material-ui-icons.development.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel">
+    const {
+      ThemeProvider, createTheme, CssBaseline,
+      Container, Grid, Card, CardContent, Typography,
+      Box, Paper, TextField, IconButton, AppBar, Toolbar, Chip
+    } = MaterialUI;
+    const { PersonSearch, Group, School, Send } = MaterialUIIcons;
+
+    const agentDetails = {
+      recrutamento: { name: 'Especialista em Recrutamento', icon: PersonSearch },
+      engajamento: { name: 'Especialista em Engajamento', icon: Group },
+      treinamento: { name: 'Especialista em Treinamento', icon: School }
+    };
+
+    function AgentSelection({ onSelect }) {
+      return (
+        <Container sx={{ mt: 4 }}>
+          <Grid container spacing={2} justifyContent="center">
+            {Object.entries(agentDetails).map(([key, { name, icon: Icon }]) => (
+              <Grid item xs={12} sm={4} key={key}>
+                <Card onClick={() => onSelect(key)} sx={{ textAlign: 'center', cursor: 'pointer' }}>
+                  <CardContent>
+                    <Icon sx={{ fontSize: 40, color: 'primary.main' }} />
+                    <Typography variant="h6">{name}</Typography>
+                  </CardContent>
+                </Card>
+              </Grid>
+            ))}
+          </Grid>
+        </Container>
+      );
+    }
+
+    function Chat({ name, messages, onSend }) {
+      const [input, setInput] = React.useState('');
+      const messagesEnd = React.useRef(null);
+      React.useEffect(() => {
+        messagesEnd.current?.scrollIntoView({ behavior: 'smooth' });
+      }, [messages]);
+      const handleSend = () => {
+        const text = input.trim();
+        if (!text) return;
+        onSend(text);
+        setInput('');
+      };
+      return (
+        <Container sx={{ mt: 4 }}>
+          <Typography variant="h5" gutterBottom>{name}</Typography>
+          <Paper sx={{ p: 2, height: 300, overflowY: 'auto', mb: 2 }}>
+            {messages.map((m, i) => (
+              <Box key={i} sx={{ textAlign: m.sender === 'Você' ? 'right' : 'left', mb: 1 }}>
+                <Chip color={m.sender === 'Você' ? 'primary' : 'default'} label={`${m.sender}: ${m.text}`} />
+              </Box>
+            ))}
+            <div ref={messagesEnd} />
+          </Paper>
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <TextField
+              fullWidth
+              placeholder="Digite sua pergunta"
+              value={input}
+              onChange={e => setInput(e.target.value)}
+              onKeyPress={e => { if (e.key === 'Enter') handleSend(); }}
+            />
+            <IconButton color="primary" onClick={handleSend}>
+              <Send />
+            </IconButton>
+          </Box>
+        </Container>
+      );
+    }
+
+    function App() {
+      const [currentAgent, setCurrentAgent] = React.useState(null);
+      const [messages, setMessages] = React.useState([]);
+
+      const selectAgent = agent => {
+        setCurrentAgent(agent);
+        setMessages([]);
+      };
+
+      const sendMessage = async text => {
+        setMessages(msgs => [...msgs, { sender: 'Você', text }]);
+        const res = await fetch('/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ agent: currentAgent, message: text })
+        });
+        const data = await res.json();
+        setMessages(msgs => [...msgs, { sender: agentDetails[currentAgent].name, text: data.reply }]);
+      };
+
+      return (
+        <Box>
+          <AppBar position="static">
+            <Toolbar>
+              <Typography variant="h6" sx={{ flexGrow: 1 }}>Especialistas de RH</Typography>
+            </Toolbar>
+          </AppBar>
+          {!currentAgent ? (
+            <AgentSelection onSelect={selectAgent} />
+          ) : (
+            <Chat name={agentDetails[currentAgent].name} messages={messages} onSend={sendMessage} />
+          )}
+        </Box>
+      );
+    }
+
+    const theme = createTheme({
+      palette: {
+        primary: { main: '#1976d2' },
+        background: { default: '#ffffff' }
+      }
+    });
+
+    ReactDOM.createRoot(document.getElementById('root')).render(
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <App />
+      </ThemeProvider>
+    );
+  </script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,70 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const agents = {
+  recrutamento: 'Você é um especialista em recrutamento e seleção, ajudando com estratégias para encontrar e contratar os melhores talentos.',
+  engajamento: 'Você é um especialista em engajamento de colaboradores, fornecendo dicas para motivação e satisfação no trabalho.',
+  treinamento: 'Você é um especialista em treinamento e desenvolvimento, orientando planos de capacitação e crescimento profissional.'
+};
+
+const server = http.createServer(async (req, res) => {
+  if (req.method === 'GET') {
+    const filePath = path.join(__dirname, 'public', req.url === '/' ? 'index.html' : req.url);
+    fs.readFile(filePath, (err, data) => {
+      if (err) {
+        res.writeHead(404);
+        res.end('Not found');
+      } else {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(data);
+      }
+    });
+  } else if (req.method === 'POST' && req.url === '/chat') {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', async () => {
+      try {
+        const { agent, message } = JSON.parse(body);
+        const system = agents[agent] || 'Você é um assistente de RH.';
+        const apiKey = process.env.OPENAI_API_KEY;
+        let reply = 'Configuração de API ausente.';
+        if (apiKey) {
+          try {
+            const resp = await fetch('https://api.openai.com/v1/chat/completions', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${apiKey}`
+              },
+              body: JSON.stringify({
+                model: 'gpt-4o-mini',
+                messages: [
+                  { role: 'system', content: system },
+                  { role: 'user', content: message }
+                ]
+              })
+            });
+            const data = await resp.json();
+            reply = data?.choices?.[0]?.message?.content || 'Sem resposta.';
+          } catch (e) {
+            reply = 'Erro ao consultar o modelo.';
+          }
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ reply }));
+      } catch (e) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Erro no servidor' }));
+      }
+    });
+  } else {
+    res.writeHead(404);
+    res.end('Not found');
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Servidor iniciado na porta ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- enhance React interface with Material UI, blue/white theme and icon cards for each specialist
- style chat area using Material UI components for responsive layout
- update documentation to note Material UI-based interface

## Testing
- `npm test`
- `node server.js` and `curl http://localhost:3000`


------
https://chatgpt.com/codex/tasks/task_e_68a60ad206788332bec6545906a8fe38